### PR TITLE
Task 7: Authorization

### DIFF
--- a/src/services/authorization-service/.gitignore
+++ b/src/services/authorization-service/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/src/services/authorization-service/handler.js
+++ b/src/services/authorization-service/handler.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports.hello = async (event) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify(
+      {
+        message: 'Go Serverless v1.0! Your function executed successfully!',
+        input: event,
+      },
+      null,
+      2
+    ),
+  };
+
+  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+  // return { message: 'Go Serverless v1.0! Your function executed successfully!', event };
+};

--- a/src/services/authorization-service/serverless.yml
+++ b/src/services/authorization-service/serverless.yml
@@ -1,0 +1,22 @@
+service: authorization-service
+frameworkVersion: "3"
+useDotenv: true
+provider:
+  name: aws
+  runtime: nodejs14.x
+  stage: dev
+  region: us-east-1
+functions:
+  hello:
+    handler: handler.basicAuthorizer
+plugins:
+  - serverless-auto-swagger
+  - serverless-esbuild
+  - serverless-dotenv-plugin
+custom:
+  autoswagger:
+    apiType: http
+    generateSwaggerOnDeploy: true
+  esbuild:
+    bundle: true
+    minify: false

--- a/src/services/authorization-service/serverless.yml
+++ b/src/services/authorization-service/serverless.yml
@@ -7,16 +7,12 @@ provider:
   stage: dev
   region: us-east-1
 functions:
-  hello:
+  basicAuthorizer:
     handler: handler.basicAuthorizer
 plugins:
-  - serverless-auto-swagger
   - serverless-esbuild
   - serverless-dotenv-plugin
 custom:
-  autoswagger:
-    apiType: http
-    generateSwaggerOnDeploy: true
   esbuild:
     bundle: true
     minify: false

--- a/src/services/import-service/serverless.yml
+++ b/src/services/import-service/serverless.yml
@@ -31,6 +31,12 @@ functions:
           path: import
           method: get
           cors: true
+          authorizer:
+            name: basicAuthorizer
+            arn: arn:aws:lambda:us-east-1:773707999966:function:authorization-service-dev-basicAuthorizer
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            type: TOKEN
           request:
             parameters:
               querystrings:


### PR DESCRIPTION
FE PR: [https://github.com/FilipNedovic/shop-react-redux-cloudfront/pull/6](https://github.com/FilipNedovic/shop-react-redux-cloudfront/pull/6)
CloudFront application: [d3fnxdikaqjnst.cloudfront.net](d3fnxdikaqjnst.cloudfront.net)

**What was done:**
- created `authorization-service` with its own `serverless.yml` file
- created `basicAuthorizer` lambda function and added lambda authorization to the `/import` path
- request to the `importProductsFile` lambda works only with correct 1 `authorization_token` being decoded and checked by `basicAuthorizer` lambda
- client application updated to send "Authorization: Basic `authorization_token`" header on import (gets its value from browser localStorage)
- client application displays alerts for the responses in 401 and 403 statuses